### PR TITLE
Adopt 'src/' layout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.12b0
+  rev: 22.3.0
   hooks:
   - id: black
     exclude: "^({{cookiecutter.project_slug}}/)"
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.6.0
+  rev: v3.1.0
   hooks:
   - id: reorder-python-imports
     args: ["--py37-plus"]

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -8,7 +8,8 @@ import sys
 PROTOS_DIR = "{{ cookiecutter.protos_dir }}"
 
 DEST_PATH = (
-    pathlib.Path("ansys")
+    pathlib.Path("src")
+    / "ansys"
     / "api"
     / "{{ cookiecutter.product_name | slugify(separator='_') }}"
     / "{{ cookiecutter.library_name | slugify(separator='_') }}"

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -15,7 +15,7 @@ with open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
 product = "{{ cookiecutter.product_name | slugify(separator='_') }}"
 library = "{{ cookiecutter.library_name | slugify(separator='_') }}"
 package_info = ["ansys", "api", product, library, "v{{ cookiecutter.api_version }}"]
-with open(os.path.join(HERE, "ansys", "api", product, library, "VERSION"), encoding="utf-8") as f:
+with open(os.path.join(HERE, "src", "ansys", "api", product, library, "VERSION"), encoding="utf-8") as f:
     version = f.read().strip()
 
 package_name = "{{ cookiecutter.project_slug | lower }}"
@@ -36,7 +36,8 @@ if __name__ == "__main__":
         license="MIT",
         python_requires=">=3.7",
         install_requires=["grpcio~=1.17", "protobuf~=3.19"{% for mod in cookiecutter.proto_dependencies['modules'] %}, "{{ mod }}"{% endfor %}],
-        packages=setuptools.find_namespace_packages(".", include=("ansys.*",)),
+        package_dir = {"": "src"},
+        packages=setuptools.find_namespace_packages("src", include=("ansys.*",)),
         package_data={
             "": ["*.proto", "*.pyi", "py.typed", "VERSION"],
         },


### PR DESCRIPTION
Fixes #7.

If the `ansys/` directory is at the top-level, the protoc compilation will fail if there is already a `build/` directory containing `.proto` files. This can be avoided by adopting a `src/` layout instead.

In the `ansys-tools-protoc-helper`, there isn't _really_ a great way to avoid this, since the directory above `ansys/` needs to be passed to `protoc`.