### PR TITLE
Fix ci.yml template substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Before using the template, run this command, preferably in a virtual environment
 package dependencies:
 
 ```bash
-pip install cookiecutter
+pip install 'cookiecutter~=2.0'
 ```
 
 Next, create your repository via ssh with this command:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,8 +3,8 @@
     "library_name": "",
     "project_slug": "ansys-api-{{ '-'.join([cookiecutter.product_name, cookiecutter.library_name]) | slugify }}",
     "api_version": "0",
-    "_dot_package_name_no_ver": "ansys.api.{{ cookiecutter.product_name | slugify(separator='_') }}.{{ cookiecutter.library_name | slugify(separator='_') }}",
-    "_dot_package_name": "{{ cookiecutter._dot_package_name_no_ver }}.v{{ cookiecutter.api_version }}",
+    "__dot_package_name_no_ver": "ansys.api.{{ cookiecutter.product_name | slugify(separator='_') }}.{{ cookiecutter.library_name | slugify(separator='_') }}",
+    "__dot_package_name": "{{ cookiecutter.__dot_package_name_no_ver }}.v{{ cookiecutter.api_version }}",
     "api_package_version": "0.1.0",
     "protos_dir": "",
     "proto_dependencies": {

--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
         run: |
           mkdir tmp
           cd tmp
-          python -c "import {{ cookiecutter._dot_package_name }}; print('Sucessfully imported {{ cookiecutter._dot_package_name }}')"
-          python -c "from {{ cookiecutter._dot_package_name }} import __version__; print(__version__)"
+          python -c "import {{ cookiecutter.__dot_package_name }}; print('Sucessfully imported {{ cookiecutter.__dot_package_name }}')"
+          python -c "from {{ cookiecutter.__dot_package_name }} import __version__; print(__version__)"
       - name: Upload packages
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Use rendered (double-underscore prefixed) private variables in `ci.yml`,
see https://cookiecutter.readthedocs.io/en/stable/advanced/private_variables.html#private-variables.

This seems to be a new feature in cookiecutter version 2.x, so the install
instructions in the `README` are adapted accordingly.

Fixes #9.